### PR TITLE
Check and fix configuration file bugs

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -52,7 +52,7 @@ unbind -T copy-mode-vi Enter
 ## クリップボード共有を有効にする
 ### for mac
 if "which pbcopy" "bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'pbcopy'"
-if "which pocopy" "bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'pbcopy'"
+if "which pbcopy" "bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'pbcopy'"
 ### for Linux
 if "which xsel" "bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'xsel -bi'"
 if "which xsel" "bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'xsel -bi'"

--- a/.zshrc
+++ b/.zshrc
@@ -33,7 +33,10 @@ case "$(uname -s)" in
     ;;
 esac
 
-source "$(brew --prefix)/etc/profile.d/z.sh"
+# z.shをロードする（macOSのみ）
+if [[ "$(uname -s)" == "Darwin"* ]] && command -v brew >/dev/null 2>&1; then
+    [ -f "$(brew --prefix)/etc/profile.d/z.sh" ] && source "$(brew --prefix)/etc/profile.d/z.sh"
+fi
 
 if command -v sheldon >/dev/null 2>&1; then
     eval "$(sheldon source)"

--- a/.zshrc
+++ b/.zshrc
@@ -25,6 +25,8 @@ case "$(uname -s)" in
     # macOS ARM前提のパス
     export PATH="/opt/homebrew/bin:${PATH}"
     source "$(brew --prefix asdf)"/libexec/asdf.sh
+    # z.shをロードする
+    [ -f "$(brew --prefix)/etc/profile.d/z.sh" ] && source "$(brew --prefix)/etc/profile.d/z.sh"
     ;;
 
   Linux*)
@@ -32,11 +34,6 @@ case "$(uname -s)" in
     source "${HOME}"/.asdf/asdf.sh
     ;;
 esac
-
-# z.shをロードする（macOSのみ）
-if [[ "$(uname -s)" == "Darwin"* ]] && command -v brew >/dev/null 2>&1; then
-    [ -f "$(brew --prefix)/etc/profile.d/z.sh" ] && source "$(brew --prefix)/etc/profile.d/z.sh"
-fi
 
 if command -v sheldon >/dev/null 2>&1; then
     eval "$(sheldon source)"

--- a/.zshrc
+++ b/.zshrc
@@ -25,7 +25,6 @@ case "$(uname -s)" in
     # macOS ARM前提のパス
     export PATH="/opt/homebrew/bin:${PATH}"
     source "$(brew --prefix asdf)"/libexec/asdf.sh
-    # z.shをロードする
     [ -f "$(brew --prefix)/etc/profile.d/z.sh" ] && source "$(brew --prefix)/etc/profile.d/z.sh"
     ;;
 

--- a/setup.sh
+++ b/setup.sh
@@ -19,12 +19,12 @@ readonly DOTFILES=(
 
 for file in "${DOTFILES[@]}"
 do
-  source_file=$HOME/dotfiles/$file
-  target_file=$HOME/$file
+  source_file="$(pwd)/$file"
+  target_file="$HOME/$file"
 
   # ディレクトリが無ければ作る
-  if [ ! -d "$(dirname $target_file)" ]; then
-    mkdir -p "$(dirname $target_file)"
+  if [ ! -d "$(dirname "$target_file")" ]; then
+    mkdir -p "$(dirname "$target_file")"
   fi
 
   ln -si "$source_file" "$target_file"


### PR DESCRIPTION
設定ファイルの潜在的なバグを修正し、OS間の互換性と保守性を向上させます。

`setup.sh`のパス処理の堅牢性を高め、`.zshrc`ではmacOS固有の設定を整理し、`.tmux.conf`のタイプミスを修正しました。